### PR TITLE
Fix deprecation warning introduced in 2.20.0

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,58 @@
+---
+name: Terraform
+
+on:
+  pull_request:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform Format
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: fmt
+          tf_actions_comment: true
+
+  terraform-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform Init
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: init
+          tf_actions_comment: true
+      - name: Terraform Validate
+        uses: hashicorp/terraform-github-actions@master
+        env:
+          AWS_DEFAULT_REGION: eu-west-1
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: validate
+          tf_actions_comment: true
+
+  terraform-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Update module usage docs and push any changes back to PR branch
+        uses: Dirrk/terraform-docs@v1.0.8
+        with:
+          tf_docs_args: '--sort-inputs-by-required'
+          tf_docs_git_commit_message: 'terraform-docs: Update module usage'
+          tf_docs_git_push: 'true'
+          tf_docs_output_file: README.md
+          tf_docs_output_method: inject
+          tf_docs_find_dir: .

--- a/README.md
+++ b/README.md
@@ -3,6 +3,43 @@ A module for building Datadog monitors in Terraform
 
 
 <!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| datadog | >= 2.20.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| datadog | >= 2.20.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dashboard | The Datadog dashboard URL shown in the alert message | `string` | `""` | no |
+| evaluation\_delay | Seconds to delay evaluation to ensure the monitor has a full data period | `number` | `null` | no |
+| include\_tags | Whether to insert the triggering tags into the monitoring title | `bool` | `true` | no |
+| monitors | The set of monitor specific attributes per monitor | <pre>map(object({<br>    name       = string<br>    message    = string<br>    query      = string<br>    thresholds = map(string)<br>    type       = string<br>  }))</pre> | `null` | no |
+| new\_host\_delay | Seconds after booting before starting the evaluation of monitor results | `number` | `null` | no |
+| no\_data\_timeframe | The number of minutes before a monitor will notify when data stops reporting | `number` | `null` | no |
+| notifiers | The notifiers to which the alerts get send | `list(string)` | `[]` | no |
+| notify\_no\_data | Whether this monitor will notify when data stops reporting | `bool` | `true` | no |
+| renotify\_interval | The number of minutes before a monitor will re-notify on the current status | `number` | `null` | no |
+| require\_full\_window | A boolean indicating whether the monitor needs a full window of data before it's evaluated | `bool` | `true` | no |
+| tag\_list | A list of tags to assign to the role | `list(string)` | `[]` | no |
+| tag\_map | A map of tags to assign to the role | `map(string)` | `{}` | no |
+| timeout | Hours of not reporting data before automatically resolving from a triggered state | `number` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| monitor\_ids | A map with all monitor names and IDs |
+
 <!--- END_TF_DOCS --->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # terraform-datadog-mcaf-monitor
 A module for building Datadog monitors in Terraform
+
+
+<!--- BEGIN_TF_DOCS --->
+<!--- END_TF_DOCS --->
+
+## License
+
+**Copyright:** Schuberg Philis
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,19 @@ resource "datadog_monitor" "default" {
   renotify_interval   = var.renotify_interval
   require_full_window = var.require_full_window
   timeout_h           = var.timeout
-  thresholds          = each.value.thresholds
   type                = each.value.type
   tags                = local.tags
+
+  dynamic "monitor_thresholds" {
+    for_each = each.value.thresholds != null ? { create : true } : {}
+
+    content {
+      ok                = try(each.value.thresholds["ok"], null)
+      warning           = try(each.value.thresholds["warning"], null)
+      critical          = try(each.value.thresholds["critical"], null)
+      unknown           = try(each.value.thresholds["unknown"], null)
+      warning_recovery  = try(each.value.thresholds["warning_recovery"], null)
+      critical_recovery = try(each.value.thresholds["critical_recovery"], null)
+    }
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     datadog = {
-      source = "datadog/datadog"
+      source  = "datadog/datadog"
+      version = ">= 2.20.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Fix deprecation warning introduced in provider version [2.20.0](https://github.com/DataDog/terraform-provider-datadog/blob/master/CHANGELOG.md#2200-january-20-2021)

Also added PR checks and documentation generation