### PR TITLE
Bump to latest version to support new attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A module for building Datadog monitors in Terraform
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| datadog | >= 2.20.0 |
+| datadog | >= 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| datadog | >= 2.20.0 |
+| datadog | >= 3.3.0 |
 
 ## Inputs
 
@@ -24,7 +24,7 @@ A module for building Datadog monitors in Terraform
 | evaluation\_delay | Seconds to delay evaluation to ensure the monitor has a full data period | `number` | `null` | no |
 | include\_tags | Whether to insert the triggering tags into the monitoring title | `bool` | `true` | no |
 | monitors | The set of monitor specific attributes per monitor | <pre>map(object({<br>    name       = string<br>    message    = string<br>    query      = string<br>    thresholds = map(string)<br>    type       = string<br>  }))</pre> | `null` | no |
-| new\_host\_delay | Seconds after booting before starting the evaluation of monitor results | `number` | `null` | no |
+| new\_group\_delay | Seconds after booting before starting the evaluation of monitor results | `number` | `null` | no |
 | no\_data\_timeframe | The number of minutes before a monitor will notify when data stops reporting | `number` | `null` | no |
 | notifiers | The notifiers to which the alerts get send | `list(string)` | `[]` | no |
 | notify\_no\_data | Whether this monitor will notify when data stops reporting | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "datadog_monitor" "default" {
   query               = each.value.query
   evaluation_delay    = var.evaluation_delay
   include_tags        = var.include_tags
-  new_host_delay      = var.new_host_delay
+  new_group_delay     = var.new_group_delay
   no_data_timeframe   = var.no_data_timeframe
   notify_no_data      = var.notify_no_data
   renotify_interval   = var.renotify_interval

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "monitors" {
   description = "The set of monitor specific attributes per monitor"
 }
 
-variable "new_host_delay" {
+variable "new_group_delay" {
   type        = number
   default     = null
   description = "Seconds after booting before starting the evaluation of monitor results"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 2.20.0"
+      version = ">= 3.3.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Bump requirement to the latest version [`3.3.0`](https://github.com/DataDog/terraform-provider-datadog/blob/master/CHANGELOG.md#330-august-26-2021) and replace `new_host_delay` with the new `new_group_delay`.

See also: https://github.com/DataDog/terraform-provider-datadog/pull/1176